### PR TITLE
change: added templates field

### DIFF
--- a/input/v1beta1/input.go
+++ b/input/v1beta1/input.go
@@ -40,7 +40,8 @@ const (
 )
 
 type TemplateSourceInline struct {
-	Template string `json:"template,omitempty"`
+	Template  string   `json:"template,omitempty"`
+	Templates []string `json:"templates,omitempty"`
 }
 
 type TemplateSourceFileSystem struct {

--- a/template.go
+++ b/template.go
@@ -48,12 +48,16 @@ func (is *InlineSource) GetTemplates() string {
 }
 
 func newInlineSource(in *v1beta1.GoTemplate) (*InlineSource, error) {
-	if in.Inline == nil || in.Inline.Template == "" {
-		return nil, errors.New("inline.template should be provided")
+	if in.Inline == nil || (in.Inline.Template == "" && len(in.Inline.Templates) == 0) {
+		return nil, errors.New("inline.template or inline.templates should be provided")
 	}
-
+	tpl := in.Inline.Template
+	for _, t := range in.Inline.Templates {
+		tpl += "\n---\n"
+		tpl += t
+	}
 	return &InlineSource{
-		Template: in.Inline.Template,
+		Template: tpl,
 	}, nil
 }
 


### PR DESCRIPTION
### Description of your changes

k8s config toolings like kustomize allows manipulation of yaml object and arrays. In current state of function-go-templating if an inline template grows too big it is not possible to split it with kustomize because kustomize won't do string concatenation. If  there is a templates array of strings fields along side template. That can allow patching through kustomize.


- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
